### PR TITLE
Fixed: if Chrome shows a translation option, the wheel should be next to it, not over it

### DIFF
--- a/src/content_scripts/wtm-report/index.js
+++ b/src/content_scripts/wtm-report/index.js
@@ -61,7 +61,11 @@ function renderWheel(anchor, stats) {
     container.style.left = threeDotsElement.getBoundingClientRect().right - parent.getBoundingClientRect().left + 5 + 'px';
   } else {
     // default path in Chrome
-    const arrowDown = parent.querySelector('span.gTl8xb');
+    let arrowDown = parent.querySelector('span.gTl8xb');
+    if (arrowDown) {
+      const translateNextToArrow = parent.querySelector('a.iUh30 > span');
+      arrowDown = translateNextToArrow || arrowDown;
+    }
     const elem = arrowDown || parent.querySelector('cite > span');
     const offset = arrowDown ? 10 : 5;
     container.style.left = elem.getBoundingClientRect().right - parent.getBoundingClientRect().left + offset + 'px';


### PR DESCRIPTION
The last fix (https://github.com/ghostery/ghostery-dnr-extension/pull/38) missed the option of translations shown by Chrome. It should not draw the wheel on the translation text (e.g. "Diese Seite übersetzen"). Now looks like that:

![translation_option](https://user-images.githubusercontent.com/1616509/141767075-e92a92fb-6dbd-4c31-b6fa-e4288a51143e.png)



