### PR TITLE
Fix: tracker stats should reset on redirects

### DIFF
--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -89,7 +89,7 @@ function resetUpdateIconDebounceMode() {
   });
 }
 
-chrome.webNavigation.onBeforeNavigate.addListener(({ tabId, frameId, url }) => {
+chrome.webNavigation.onCommitted.addListener(({ tabId, frameId, url }) => {
   if (frameId !== 0) {
     return;
   }


### PR DESCRIPTION
`onBeforeNaviagate` denotes that start of the transition chain, while `onCommitted` is bound to the document livecycle. `onCommitted` should also fire on cold starts.