### PR TITLE
Detect navigation events in Safari when clicking on bookmarks

### DIFF
--- a/src/content_scripts/whotracksme/index.js
+++ b/src/content_scripts/whotracksme/index.js
@@ -10,11 +10,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
 
-function postMessage({ urls }) {
-  chrome.runtime.sendMessage({ action: "updateTabStats", args: [{ urls }]});
-}
-
 const origin = (new URL(window.location.href)).origin;
+
+let firstCall = true;
+function postMessage({ urls }) {
+  chrome.runtime.sendMessage({ action: "updateTabStats", args: [{
+    urls,
+    firstCall,
+    origin,
+  }]});
+  firstCall = false;
+}
 
 const start = Date.now();
 let loadTime = 0;


### PR DESCRIPTION
On Safari, "webNavigation.onCommitted" is not reliable. When clicking on bookmarks, it will not trigger - at least not for the target tabId. To prevent loosing the events, we can instead listen for navigation events by marking the first message sent from the content script.
