### PR TITLE
Workaround for Safari's "webNavigation.onCommitted" handling for bookmarks 

### DIFF
--- a/src/content_scripts/whotracksme/index.js
+++ b/src/content_scripts/whotracksme/index.js
@@ -14,6 +14,12 @@ function postMessage({ urls }) {
   chrome.runtime.sendMessage({ action: "updateTabStats", args: [{ urls }]});
 }
 
+// Should only be needed on Safari:
+// the tabId of the initial chrome.webNavigation.onCommitted
+// is not reliable. When opening bookmarks, it can happen that
+// the event is associated with a tabId of 0.
+chrome.runtime.sendMessage({ action: "onCommitted" });
+
 const origin = (new URL(window.location.href)).origin;
 
 const start = Date.now();
@@ -55,7 +61,7 @@ window.addEventListener('load', () => {
     // Send back the sources of every script and image in the DOM back to the host application.
     [].slice.apply(document.scripts).forEach(function(el) { sendMessage(el.src, 'load script'); });
     [].slice.apply(document.images).forEach(function(el) { sendMessage(el.src, 'load image'); });
-    [].slice.apply(document.getElementsByTagName('iframe')).forEach(function(el) { sendMessage(el.src, 'load iframe'); })
+    [].slice.apply(document.getElementsByTagName('iframe')).forEach(function(el) { sendMessage(el.src, 'load iframe'); });
   }
 
   window.addEventListener("load", onLoadNativeCallback, false);

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -115,13 +115,20 @@ function resetUpdateIconDebounceMode() {
   });
 }
 
+function userNavigatedToNewPage({ tabId, domain }) {
+  tabStats.set(tabId, { domain, trackers: [], loadTime: 0 });
+  resetUpdateIconImmediateMode();
+}
+
 chrome.webNavigation.onCommitted.addListener(({ tabId, frameId, url }) => {
   if (frameId !== 0) {
     return;
   }
   const { domain } = tldts.parse(url);
-  tabStats.set(tabId, { domain, trackers: [], loadTime: 0 });
-  resetUpdateIconImmediateMode();
+  if (!domain) {
+    return;
+  }
+  userNavigatedToNewPage({ tabId, domain });
 });
 
 chrome.tabs.onRemoved.addListener((tabId, removeInfo) => {
@@ -137,19 +144,35 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (sender.tab === undefined) {
     throw new Error('required "sender.tab" information is not available');
   }
-
   if (sender.tab.id === undefined) {
     throw new Error('required "sender.tab.id" information is not available');
   }
-
   if (sender.frameId === undefined) {
     throw new Error('required "sender.frameId" information is not available');
+  }
+  if (sender.url === undefined) {
+    throw new Error('required "sender.url" information is not available');
   }
 
   const tabId = sender.tab.id;
 
   if (msg.action === "updateOptions") {
     updateOptions();
+    return false;
+  }
+
+  // Workaround for Safari:
+  // We cannot trust that Safari fires "chrome.webNavigation.onCommitted"
+  // with the correct tabId (sometimes it is correct, sometimes it is 0).
+  // Thus, let the content_script redundantly fire it.
+  //
+  // (Perhaps it is a bug in Safari. It can be triggered by opening
+  //  a bookmarked page from a new tab.)
+  if (msg.action === "onCommitted") {
+    const { domain } = tldts.parse(sender.url);
+    if (domain) {
+      userNavigatedToNewPage({ tabId, domain });
+    }
     return false;
   }
 


### PR DESCRIPTION
On Safari, "webNavigation.onCommitted" is not reliable. When clicking on bookmarks, it will not trigger - at least not for the target tabId, it might be 0. To prevent loosing the events, we can instead send a message from the content script to force the reset.

Revised version of https://github.com/ghostery/ghostery-dnr-extension/pull/53. Also, supports bookmarked sites that do not have any tracker.