### PR TITLE
Fixed link tracking removal

### DIFF
--- a/src/content_scripts/prevent-serp-tracking/index.js
+++ b/src/content_scripts/prevent-serp-tracking/index.js
@@ -30,6 +30,7 @@ function safeLinkClick(event) {
     const directUrl = new URL(link.href).searchParams.get('url');
     if (directUrl) {
       console.debug('safeLinkClick changed:', link.href, '->', directUrl);
+      event.preventDefault();
       window.location = directUrl;
     }
   } catch (e) {


### PR DESCRIPTION
It is important to prevent the execution of default handlers. Otherwise, overwriting the location will not have an effect.

(Hint: to reproduce, set the direct URL to some completely different page. Then it is easier to verify that the feature works as expected.)