### PR TITLE
Add Serp Report option with default true value

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "env": {
-    "es6": true,
+    "es2020": true,
     "browser": true,
     "node": true,
     "serviceworker": true,
@@ -11,7 +11,6 @@
     "plugin:prettier/recommended"
   ],
   "parserOptions": {
-    "ecmaVersion": 2018,
     "sourceType": "module"
   },
   "globals": {

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Von Websitebesitzern erstellte Tracker zulassen"
 	},
-	"settings_block_trackers": {
-		"message": "Neue zu Ghostery hinzugefügte Tracker standardmäßig blockieren"
-	},
 	"settings_show_purple_box": {
 		"message": "Tracker-Tally in der Ecke meines Browsers anzeigen"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "Vergewissern Sie sich, dass in Ihrer aktuellen Registerkarte eine http- oder https-Seite geöffnet ist"
+	},
+	"settings_wtm_serp_report": {
+		"message": "Tracker-Vorschau in Suchergebnissen anzeigen"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "Tracker-URLs finden Sie nach dem Klick auf einen Tracker unter der Beschreibung des Trackers."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Allow trackers created by site owners"
 	},
-	"settings_block_trackers": {
-		"message": "Block new trackers added to Ghostery by default"
-	},
 	"settings_show_purple_box": {
 		"message": "Show the tracker-tally in the corner of my browser"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "Ensure that your current tab has http or https page opened"
+	},
+	"settings_wtm_serp_report": {
+		"message": "Show Trackers Preview next to search results"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "Tracker URLs can be found below the tracker description after clicking on a tracker."

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Permitir rastreadores creados por los propietarios del sitio"
 	},
-	"settings_block_trackers": {
-		"message": "Bloquear por defecto los nuevos rastreadores agregados a Ghostery"
-	},
 	"settings_show_purple_box": {
 		"message": "Mostrar el recuento de rastreadores en la esquina de mi navegador"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "Asegúrate de que tu actual pestaña tenga abierta una página http o https"
+	},
+	"settings_wtm_serp_report": {
+		"message": "Show WhoTracks.Me Tracker Wheel next to search results"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "Las URL del rastreador se pueden encontrar debajo de la descripción del mismo, después de hacer clic en uno de ellos."

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Autoriser les mouchards générés par les créateurs de sites."
 	},
-	"settings_block_trackers": {
-		"message": "Bloquer les nouveaux mouchards ajoutés à Ghostery par défaut"
-	},
 	"settings_show_purple_box": {
 		"message": "Afficher le mouchard Tally dans le coin du navigateur"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "Assurez-vous que l'onglet ouvert affiche bien une page http ou https"
+	},
+	"settings_wtm_serp_report": {
+		"message": "Afficher l'aperçu der mouchards à côté des résultats"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "Cliquez sur le nom du mouchard pour voir son URL, affichée sous le descriptif"

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Oldaltulajdonosok által létrehozott trackerek engedélyezése"
 	},
-	"settings_block_trackers": {
-		"message": "A Ghostery-hez hozzáadott új trackerek blokkolása alapértelmezés szerint"
-	},
 	"settings_show_purple_box": {
 		"message": "Trackerek számának megjelenítése a böngésző sarkában"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "Ellenőrizze, hogy a jelenlegi lapfüle http vagy https oldalt nyitott-e meg"
+	},
+	"settings_wtm_serp_report": {
+		"message": "Show WhoTracks.Me Tracker Wheel next to search results"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "A trackerre történő kattintás után a tracker leírása alatt találhatók a tracker URL-jei."

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Consenti i tracker creati dai titolari del sito"
 	},
-	"settings_block_trackers": {
-		"message": "Blocca i nuovi tracker aggiunti a Ghostery per impostazione predefinita"
-	},
 	"settings_show_purple_box": {
 		"message": "Mostra il conteggio tracker nell'angolo del browser in uso"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "Verifica che la tua scheda attuale abbia una pagina http o https aperta"
+	},
+	"settings_wtm_serp_report": {
+		"message": "Show WhoTracks.Me Tracker Wheel next to search results"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "Puoi trovare gli URL dei tracker sotto alla descrizione del tracker, dopo aver cliccato su un tracker."

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "サイト所有者が作成したトラッカーを許可します"
 	},
-	"settings_block_trackers": {
-		"message": "Ghosteryにデフォルトで追加された新しいトラッカーをブロックします"
-	},
 	"settings_show_purple_box": {
 		"message": "ブラウザの隅に総トラッカーを表示します"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "現在のタブにhttpまたはhttpsページが開いていることを確認してください"
+	},
+	"settings_wtm_serp_report": {
+		"message": "Show WhoTracks.Me Tracker Wheel next to search results"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "トラッカーをクリックすると、トラッカーのURLがトラッカーの説明の下に表示されます。"

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "사이트 소유자가 만든 트래커 허용 "
 	},
-	"settings_block_trackers": {
-		"message": "기본적으로 Ghostery에 추가된 새로운 트래커 차단 "
-	},
 	"settings_show_purple_box": {
 		"message": "브라우저 구석에 트래커 기록 표시"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "현재 탭에 http 또는 https 페이지가 열려 있는지 확인하십시오 "
+	},
+	"settings_wtm_serp_report": {
+		"message": "Show WhoTracks.Me Tracker Wheel next to search results"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "트래커 URL은 트래커를 클릭한 후 나오는 트래커 설명 아래에서 찾을 수 있습니다."

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Sta door website-eigenaren gemaakte trackers toe"
 	},
-	"settings_block_trackers": {
-		"message": "Blokkeer standaard nieuwe aan Ghostery toegevoegde trackers"
-	},
 	"settings_show_purple_box": {
 		"message": "De trackertelling in de hoek van mijn browser weergeven"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "Controleer of je huidige tab een http of https pagina open heeft"
+	},
+	"settings_wtm_serp_report": {
+		"message": "Show WhoTracks.Me Tracker Wheel next to search results"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "Tracker URLs kun je vinden onder de tracker-omschrijving nadat je op een tracker geklikt hebt."

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Zezwól działanie tropicieli utworzonych przez właścicieli strony"
 	},
-	"settings_block_trackers": {
-		"message": "Blokuj nowe tropiciele dodane domyślnie do Ghostery"
-	},
 	"settings_show_purple_box": {
 		"message": "Wyświetlaj licznik tropicieli w rogu wyszukiwarki"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "Upewnij się, że aktualna zakładka ma otwartą stronę http lub https"
+	},
+	"settings_wtm_serp_report": {
+		"message": "Wyświetlaj podgląd trackerów przy wynikach wyszukiwania"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "Adresy URL tropiciela dostępne są pod opisem tropiciela po kliknięciu na danego tropiciela."

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Permitir rastreadores criados pelos criadores do site"
 	},
-	"settings_block_trackers": {
-		"message": "Bloquear novos rastreadores adicionados ao Ghostery por padrão"
-	},
 	"settings_show_purple_box": {
 		"message": "Mostrar a contagem de rastreamento no canto do meu navegador"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "Certifique-se de que sua aba atual tenha uma página http ou https aberta"
+	},
+	"settings_wtm_serp_report": {
+		"message": "Show WhoTracks.Me Tracker Wheel next to search results"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "URLs de rastreadores podem ser encontrados abaixo da descrição do rastreador clicando no rastreador."

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "Разрешить трекеры, созданные владельцами сайтов"
 	},
-	"settings_block_trackers": {
-		"message": "Блокировать новые трекеры, добавленные в Ghostery по умолчанию"
-	},
 	"settings_show_purple_box": {
 		"message": "Показывать счетчик трекеров в углу браузера"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "Убедитесь, что на вашей текущей вкладке открыта страница http или https"
+	},
+	"settings_wtm_serp_report": {
+		"message": "Show WhoTracks.Me Tracker Wheel next to search results"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "URL-адреса трекера можно найти под описанием трекера после нажатия на трекер."

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "允许网站所有者创建的跟踪器"
 	},
-	"settings_block_trackers": {
-		"message": "默认拦截添加到 Ghostery 的新跟踪器"
-	},
 	"settings_show_purple_box": {
 		"message": "在浏览器一角显示跟踪器记录"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "确保您当前的标签页中打开了 http 或 https 网页"
+	},
+	"settings_wtm_serp_report": {
+		"message": "Show WhoTracks.Me Tracker Wheel next to search results"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "点击跟踪器后，可以在跟踪器描述下方找到跟踪器网址。"

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -846,9 +846,6 @@
 	"settings_allow_trackers": {
 		"message": "准許由網站擁有者所創造的網頁跟縱器"
 	},
-	"settings_block_trackers": {
-		"message": "默認封鎖被加入 Ghostery 的新網頁跟蹤器"
-	},
 	"settings_show_purple_box": {
 		"message": "在瀏覽器角落顯示追蹤器紀錄"
 	},
@@ -977,6 +974,9 @@
 	},
 	"not_http_page": {
 		"message": "確保您當前的標簽打開了 http 或 https 網頁"
+	},
+	"settings_wtm_serp_report": {
+		"message": "Show WhoTracks.Me Tracker Wheel next to search results"
 	},
 	"settings_show_patterns_tooltip": {
 		"message": "在點擊一個網頁跟蹤器之後，可在網頁跟蹤器描述之下找到網頁跟蹤器的 URLs。"

--- a/src/options/components/ghostery-options.js
+++ b/src/options/components/ghostery-options.js
@@ -20,9 +20,16 @@ const Options = {
       const storage = await chrome.storage.local.get(['options']);
       return storage.options || {};
     },
-    set(_, options) {
-      chrome.storage.local.set({ options });
+    async set(_, options, keys) {
+      const prevOptions = await this.get();
+      const nextOptions = {
+        ...prevOptions,
+        ...Object.fromEntries(keys.map((key) => [key, options[key]])),
+      };
+
+      chrome.storage.local.set({ options: nextOptions });
       chrome.runtime.sendMessage({ action: 'updateOptions' });
+
       return options;
     },
   },

--- a/src/options/components/ghostery-options.js
+++ b/src/options/components/ghostery-options.js
@@ -14,31 +14,18 @@ import { t } from '/vendor/@whotracksme/ui/src/i18n.js';
 
 const Options = {
   trackerWheelDisabled: false,
+  wtmSerpReport: true,
   [store.connect]: {
     get: async () => {
       const storage = await chrome.storage.local.get(['options']);
-      const options = storage.options || {};
-      if (typeof options.trackerWheelDisabled === 'undefined') {
-        options.trackerWheelDisabled = false;
-      }
-      return options;
+      return storage.options || {};
     },
     set: (_, options) => {
       chrome.storage.local.set({ options });
-      chrome.runtime.sendMessage({ action: 'updateOptions' });
       return options;
     },
   },
 };
-
-function updateOptions(host) {
-  const shadowRoot = host.render();
-  const options = { ...host.options };
-  options.trackerWheelDisabled = shadowRoot.querySelector(
-    '#trackerWheelDisabled',
-  ).checked;
-  store.set(Options, options);
-}
 
 define({
   tag: 'ghostery-options',
@@ -53,15 +40,24 @@ define({
       html`
         <ul>
           <li>
-            <label for="trackerWheelDisabled"
-              >${t('options_tracker_wheel_disabled')}</label
-            >
-            <input
-              type="checkbox"
-              id="trackerWheelDisabled"
-              checked="${options.trackerWheelDisabled}"
-              onchange="${updateOptions}"
-            />
+            <label>
+              <span>${t('options_tracker_wheel_disabled')}</span>
+              <input
+                type="checkbox"
+                checked="${options.trackerWheelDisabled}"
+                onchange="${html.set(options, 'trackerWheelDisabled')}"
+              />
+            </label>
+          </li>
+          <li>
+            <label>
+              <span>${t('settings_wtm_serp_report')}</span>
+              <input
+                type="checkbox"
+                checked="${options.wtmSerpReport}"
+                onchange="${html.set(options, 'wtmSerpReport')}"
+              />
+            </label>
           </li>
         </ul>
       `}
@@ -107,6 +103,8 @@ define({
       align-items: center;
     }
     li label {
+      display: flex;
+      justify-content: space-between;
       flex: 1;
       cursor: pointer;
     }

--- a/src/options/components/ghostery-options.js
+++ b/src/options/components/ghostery-options.js
@@ -16,12 +16,13 @@ const Options = {
   trackerWheelDisabled: false,
   wtmSerpReport: true,
   [store.connect]: {
-    get: async () => {
+    async get() {
       const storage = await chrome.storage.local.get(['options']);
       return storage.options || {};
     },
-    set: (_, options) => {
+    set(_, options) {
       chrome.storage.local.set({ options });
+      chrome.runtime.sendMessage({ action: 'updateOptions' });
       return options;
     },
   },

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -73,16 +73,12 @@ function getTrackerFromUrl(url, origin) {
 
 let options = {};
 
-(async function () {
+async function updateOptions() {
   const storage = await chrome.storage.local.get(['options']);
   options = storage.options || {};
-})();
+}
 
-chrome.storage.onChanged.addListener(function (changes) {
-  if (changes.options) {
-    options = changes.options.newValue || {};
-  }
-});
+updateOptions();
 
 // Refreshing the tracker wheel:
 // * Immediately draw it when the first data comes in
@@ -160,6 +156,11 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
 
   const tabId = sender.tab.id;
+
+  if (msg.action === 'updateOptions') {
+    updateOptions();
+    return false;
+  }
 
   // Workaround for Safari:
   // We cannot trust that Safari fires "chrome.webNavigation.onCommitted"


### PR DESCRIPTION
Fixes #69.

* `wtmSerpReport` field in options
* ~~`updateOptions` message replaced with the `chrome.storage.onChanged.addListener` api~~
* Minor UI and logic refactor on the options page
* Locales copied from `ghostery-webextension` repository with a fix for the Polish translation
* Options store configuration prevents from saving default values from a model into the storage. It might be helpful if we would like to switch the default value from `true` to `false`.