### PR TITLE
Safari: fix trackers preview

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,7 +36,7 @@
       "matches": ["*://*/*"],
       "run_at": "document_start",
       "js": [
-        "/vendor/@cliqz/adblocker-webextension-cosmetics/adblocker.umd.min.js",
+        "vendor/@cliqz/adblocker-webextension-cosmetics/adblocker.umd.min.js",
         "content_scripts/cosmetics.js"
       ]
     },
@@ -239,11 +239,11 @@
       ],
       "run_at": "document_end",
       "css": [
-        "/vendor/@whotracksme/serp-report/src/content_scripts/index.css"
+        "vendor/@whotracksme/serp-report/src/content_scripts/index.css"
       ],
       "js": [
-        "/vendor/@whotracksme/tracker-wheel/src/index.js",
-        "/vendor/@whotracksme/serp-report/src/content_scripts/index.js"
+        "vendor/@whotracksme/tracker-wheel/src/index.js",
+        "vendor/@whotracksme/serp-report/src/content_scripts/index.js"
       ]
     },
     {
@@ -446,7 +446,7 @@
       "run_at": "document_start",
       "all_frames": true,
       "js": [
-        "/vendor/@whotracksme/prevent-serp-tracking/src/index.js"
+        "vendor/@whotracksme/prevent-serp-tracking/src/index.js"
       ]
     }
   ],
@@ -501,7 +501,7 @@
     },
     {
       "resources": [
-        "/vendor/@whotracksme/serp-report/src/assets/iframe/index.html"
+        "vendor/@whotracksme/serp-report/src/assets/iframe/index.html"
       ],
       "all_frames": false,
       "matches": [

--- a/xcode/Shared (Extension)/specific/manifest.json
+++ b/xcode/Shared (Extension)/specific/manifest.json
@@ -239,11 +239,11 @@
       ],
       "run_at": "document_end",
       "css": [
-        "/vendor/@whotracksme/serp-report/src/content_scripts/index.css"
+        "vendor/@whotracksme/serp-report/src/content_scripts/index.css"
       ],
       "js": [
-        "/vendor/@whotracksme/tracker-wheel/src/index.js",
-        "/vendor/@whotracksme/serp-report/src/content_scripts/index.js"
+        "vendor/@whotracksme/tracker-wheel/src/index.js",
+        "vendor/@whotracksme/serp-report/src/content_scripts/index.js"
       ]
     },
     {
@@ -445,7 +445,7 @@
       ],
       "run_at": "document_start",
       "js": [
-        "/vendor/@whotracksme/prevent-serp-tracking/src/index.js"
+        "vendor/@whotracksme/prevent-serp-tracking/src/index.js"
       ]
     }
   ],
@@ -465,11 +465,11 @@
   ],
   "background": {
     "scripts": [
-      "/vendor/tldts/index.umd.min.js",
-      "/vendor/@cliqz/adblocker/adblocker.umd.min.js",
-      "/vendor/@whotracksme/serp-report/src/background/data.js",
-      "/vendor/@whotracksme/serp-report/src/background/index.js",
-      "/vendor/@whotracksme/tracker-wheel/src/index.js",
+      "vendor/tldts/index.umd.min.js",
+      "vendor/@cliqz/adblocker/adblocker.umd.min.js",
+      "vendor/@whotracksme/serp-report/src/background/data.js",
+      "vendor/@whotracksme/serp-report/src/background/index.js",
+      "vendor/@whotracksme/tracker-wheel/src/index.js",
       "worker/lodash-debounce.js",
       "worker/adblocker.js",
       "worker/storage.js",
@@ -501,6 +501,6 @@
   "content_security_policy" : {},
   "web_accessible_resources": [
     "content_scripts/whotracksme/ghostery-whotracksme.js",
-    "/vendor/@whotracksme/serp-report/src/assets/iframe/index.html"
+    "vendor/@whotracksme/serp-report/src/assets/iframe/index.html"
   ]
 }


### PR DESCRIPTION
For some reasons Safari does not accept absolute path in manifest.json `web_accessible_resources`