### PR TITLE
Fix label length for japanese characters

### DIFF
--- a/src/panel/components/simple-view/toggle-switch.js
+++ b/src/panel/components/simple-view/toggle-switch.js
@@ -77,7 +77,6 @@ define({
 
     button label {
       cursor: pointer;
-      width: 1px;
       white-space: wrap;
     }
 


### PR DESCRIPTION
Fixes #70. The CSS property with `width: 1px` makes Japanese text wrapping on each character. After removing this property it displays correctly. I checked on polish, and it looks ok too. It is quite a strange value for the label, so it might be there some logic behind it. Do you know something else @chrmod?

About twitter links, the first problem is about the SERP report icon, which for now is only supported on Safari and Chrome (as I checked, on Firefox we still don't have it). I couldn't reproduce the issue, even forcing google to show the result page in Japanese. 