### PR TITLE
Experimental support for autoconsent library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@cliqz/adblocker": "1.22.7",
         "@cliqz/adblocker-webextension-cosmetics": "^1.22.7",
+        "@cliqz/autoconsent": "^1.0.2",
         "@whotracksme/webextension-packages": "^0.2.0",
         "hybrids": "^7.0.5",
         "lodash-es": "^4.17.21",
@@ -178,6 +179,11 @@
         "@cliqz/adblocker-content": "^1.22.7",
         "@cliqz/adblocker-extended-selectors": "^1.22.7"
       }
+    },
+    "node_modules/@cliqz/autoconsent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cliqz/autoconsent/-/autoconsent-1.0.2.tgz",
+      "integrity": "sha512-1mQyP5yeyfkkAZMDU/3CzD48+q0BCiid/4dzoaIkiqoHHGC0PdXAQZ4OAxGlaJk/Qyub/uxsbS5KpxgUZyqZRA=="
     },
     "node_modules/@devicefarmer/adbkit": {
       "version": "2.11.3",
@@ -6300,6 +6306,11 @@
         "@cliqz/adblocker-content": "^1.22.7",
         "@cliqz/adblocker-extended-selectors": "^1.22.7"
       }
+    },
+    "@cliqz/autoconsent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cliqz/autoconsent/-/autoconsent-1.0.2.tgz",
+      "integrity": "sha512-1mQyP5yeyfkkAZMDU/3CzD48+q0BCiid/4dzoaIkiqoHHGC0PdXAQZ4OAxGlaJk/Qyub/uxsbS5KpxgUZyqZRA=="
     },
     "@devicefarmer/adbkit": {
       "version": "2.11.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@cliqz/adblocker": "1.22.7",
     "@cliqz/adblocker-webextension-cosmetics": "^1.22.7",
+    "@cliqz/autoconsent": "^1.0.2",
     "@whotracksme/webextension-packages": "^0.2.0",
     "hybrids": "^7.0.5",
     "lodash-es": "^4.17.21",

--- a/src/background/autoconsent.js
+++ b/src/background/autoconsent.js
@@ -1,0 +1,67 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+import AutoConsent from '@cliqz/autoconsent';
+
+const config = { autoOptOut: true };
+
+const consent = new AutoConsent(chrome, (tabId, message, options) => {
+  return new Promise((resolve) => {
+    chrome.tabs.sendMessage(tabId, message, options, resolve);
+  });
+});
+
+(async function loadRules() {
+  const res = await fetch(
+    chrome.runtime.getURL('node_modules/@cliqz/autoconsent/rules/rules.json'),
+  );
+  const rules = await res.json();
+  Object.keys(rules.consentomatic).forEach((name) => {
+    consent.addConsentomaticCMP(name, rules.consentomatic[name]);
+  });
+  rules.autoconsent.forEach((rule) => {
+    consent.addCMP(rule);
+  });
+})();
+
+chrome.webNavigation.onCommitted.addListener(
+  (details) => {
+    if (details.frameId === 0) {
+      consent.removeTab(details.tabId);
+    }
+  },
+  {
+    url: [{ schemes: ['http', 'https'] }],
+  },
+);
+
+chrome.runtime.onMessage.addListener(({ type }, sender) => {
+  consent.onFrame({
+    tabId: sender.tab.id,
+    frameId: sender.frameId,
+    url: sender.url,
+  });
+  if (type === 'frame' && sender.frameId === 0) {
+    if (config.autoOptOut) {
+      (async () => {
+        const cmp = await consent.checkTab(sender.tab.id);
+        await cmp.checked;
+
+        if (cmp.getCMPName() !== null && (await cmp.isPopupOpen())) {
+          await cmp.doOptOut();
+        }
+      })();
+    }
+  }
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  consent.tabCmps.delete(tabId);
+});

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -27,6 +27,8 @@ import {
   updateAdblockerEngineStatuses,
 } from './adblocker.js';
 
+import './autoconsent.js';
+
 function getTrackerFromUrl(url, origin) {
   try {
     const bugId = isBug(url);

--- a/src/content_scripts/autoconsent.js
+++ b/src/content_scripts/autoconsent.js
@@ -1,0 +1,24 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+import { handleContentMessage } from '@cliqz/autoconsent';
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  const result = handleContentMessage(message, false);
+  console.log(message, result);
+  if (result !== null) {
+    sendResponse(result);
+  }
+});
+
+chrome.runtime.sendMessage({
+  type: 'frame',
+  url: window.location.href,
+});

--- a/src/manifest.chromium.json
+++ b/src/manifest.chromium.json
@@ -40,6 +40,13 @@
       ]
     },
     {
+      "matches": ["*://*/*"],
+      "run_at": "document_end",
+      "js": [
+        "content_scripts/autoconsent.js"
+      ]
+    },
+    {
       "matches": [
         "*://*.google.com/*",
         "*://*.google.ad/*",
@@ -491,7 +498,8 @@
     {
       "resources": [
         "content_scripts/whotracksme/ghostery-whotracksme.js",
-        "vendor/@whotracksme/ui/src/tracker-wheel.js"
+        "vendor/@whotracksme/ui/src/tracker-wheel.js",
+        "node_modules/@cliqz/autoconsent/rules/rules.json"
       ],
       "all_frames": true,
       "matches": [

--- a/src/manifest.safari.json
+++ b/src/manifest.safari.json
@@ -47,6 +47,13 @@
       ]
     },
     {
+      "matches": ["*://*/*"],
+      "run_at": "document_end",
+      "js": [
+        "content_scripts/autoconsent.js"
+      ]
+    },
+    {
       "matches": [
         "*://*.google.com/*",
         "*://*.google.ad/*",
@@ -496,6 +503,7 @@
     "content_scripts/whotracksme/ghostery-whotracksme.js",
     "content_scripts/prevent-indexeddb-tracking/ghostery-prevent-indexeddb-tracking.js",
     "vendor/@whotracksme/ui/src/tracker-wheel.js",
-    "vendor/@whotracksme/serp-report/src/pages/iframe/index.html"
+    "vendor/@whotracksme/serp-report/src/pages/iframe/index.html",
+    "node_modules/@cliqz/autoconsent/rules/rules.json"
   ]
 }


### PR DESCRIPTION
Adds support for https://github.com/ghostery/autoconsent library. It requires the #92 to be merged first.