### PR TITLE
Use version from package.json

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -21,6 +21,7 @@ const argv = process.argv.slice(2).reduce((acc, arg, index, arr) => {
   return acc;
 }, {});
 
+const pkg = JSON.parse(readFileSync(resolve(pwd, 'package.json'), 'utf8'));
 const manifest = JSON.parse(
   readFileSync(
     resolve(options.srcDir, `manifest.${argv.target || 'chromium'}.json`),
@@ -109,7 +110,11 @@ options.assets.forEach((path) => {
   );
 });
 
-// Save manifest
+// --- Save manifest ---
+
+// set manifest version from package.json
+manifest.version = pkg.version;
+
 writeFileSync(
   resolve(options.outDir, 'manifest.json'),
   JSON.stringify(manifest, null, 2),

--- a/src/manifest.chromium.json
+++ b/src/manifest.chromium.json
@@ -3,8 +3,6 @@
   "author": "Ghostery",
   "name": "__MSG_name__",
   "short_name": "Ghostery",
-  "version": "9.2.1",
-  "version_name": "9.2.1",
   "default_locale": "en",
   "description": "__MSG_short_description__",
   "icons": {

--- a/src/manifest.safari.json
+++ b/src/manifest.safari.json
@@ -3,8 +3,6 @@
   "author": "Ghostery",
   "name": "Ghostery",
   "short_name": "Ghostery",
-  "version": "9.2.1",
-  "version_name": "9.2.1",
   "default_locale": "en",
   "description": "Block Ads, Trackers and Annoyances",
   "icons": {


### PR DESCRIPTION
Instead of a manual update, the build script can take the version from `package.json`, so updating the version number will only require to update it in one place.

According to the [MDN docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version_name), the `version_name` it redundant (if contains the same information), so I removed it

> If no version_name is present, the version field will be used for display purposes as well.