### PR TITLE
Add download script for fetching dynamically the DNR lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 build
+tmp
 dist
 src/_metadata
 src/vendor

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "type": "module",
   "scripts": {
     "download-cosmetics": "node scripts/download-cosmetics.js",
-    "preinstall": "rimraf src/vendor src/assets/rule_resources",
-    "postinstall": "vendor-copy && npm run download-cosmetics",
+    "download-dnr-lists": "node scripts/download-dnr-lists.js",
+    "preinstall": "rimraf src/vendor",
+    "postinstall": "vendor-copy && npm run download-cosmetics && npm run download-dnr-lists",
     "build": "node scripts/build.js",
     "build.chromium": "npm run build -- --target chromium",
     "build.safari": "npm run build -- --target safari",
@@ -45,10 +46,6 @@
     "sourceDir": "./dist/"
   },
   "vendorCopy": [
-    {
-      "from": "../ghostery-dnr-lists/build",
-      "to": "src/assets/rule_resources"
-    },
     {
       "from": "node_modules/@whotracksme/webextension-packages/packages",
       "to": "src/vendor/@whotracksme"

--- a/scripts/download-dnr-lists.js
+++ b/scripts/download-dnr-lists.js
@@ -1,0 +1,48 @@
+import shelljs from 'shelljs';
+import { writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+const REPO_URL = 'git@github.com:ghostery/ghostery-dnr-lists.git';
+
+shelljs.rm('-rf', 'tmp');
+shelljs.rm('-rf', 'src/assets/rule_resources/*.json');
+
+function writeJSONPlaceholder(path, content) {
+  writeFileSync(
+    resolve('src/assets/rule_resources/', path),
+    JSON.stringify(content),
+  );
+}
+
+try {
+  const result = shelljs.exec(`git clone ${REPO_URL} tmp/dnr-lists`);
+  if (result.code !== 0) {
+    throw Error("Couldn't clone repo");
+  }
+
+  shelljs.exec('cd tmp/dnr-lists && npm ci && npm start');
+
+  shelljs.cp('-R', 'tmp/dnr-lists/build/*.json', 'src/assets/rule_resources/');
+} catch (e) {
+  console.log('Generating placeholder DNR lists');
+
+  writeJSONPlaceholder('bugs.json', {
+    patterns: { host_path: {} },
+  });
+
+  writeJSONPlaceholder('categories.json', {});
+  writeJSONPlaceholder('trackers.json', {});
+  writeJSONPlaceholder('tracker_domains.json', {});
+
+  writeJSONPlaceholder('sites.json', []);
+
+  writeJSONPlaceholder('dnr-ads-network.json', []);
+  writeJSONPlaceholder('dnr-annoyances-network.json', []);
+  writeJSONPlaceholder('dnr-tracking-network.json', []);
+
+  writeJSONPlaceholder('dnr-safari-ads-network.json', []);
+  writeJSONPlaceholder('dnr-safari-annoyances-network.json', []);
+  writeJSONPlaceholder('dnr-safari-tracking-network.json', []);
+} finally {
+  shelljs.rm('-rf', 'tmp');
+}


### PR DESCRIPTION
Fixes #30. Fixes #31. Fixes #94.

* Removes hardcoded reference to external path (used by vendor copy)
* Adds `download-dnr-lists` npm script
* The script is added to the `postinstall` command, but it should be called before the final build for the release