### PR TITLE
Clean up DNR lists with direct import of used in source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,7 @@ tmp
 dist
 src/_metadata
 src/vendor
-src/assets/rule_resources/*
-!src/assets/rule_resources/.gitkeep
+src/rule_resources
 src/assets/adblocker_engines/*
 !src/assets/adblocker_engines/.gitkeep
 *.xcuserstate

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -164,6 +164,15 @@ manifest.web_accessible_resources?.forEach((entry) => {
   });
 });
 
+// declarative net request
+if (manifest.declarative_net_request?.rule_resources) {
+  manifest.declarative_net_request.rule_resources.forEach(({ path }) => {
+    const dir = dirname(path);
+    shelljs.mkdir('-p', resolve(options.outDir, dir));
+    shelljs.cp(resolve(options.srcDir, path), resolve(options.outDir, dir));
+  });
+}
+
 // background
 if (manifest.background) {
   source.push(manifest.background.service_worker || manifest.background.page);

--- a/scripts/download-dnr-lists.js
+++ b/scripts/download-dnr-lists.js
@@ -3,15 +3,14 @@ import { writeFileSync } from 'fs';
 import { resolve } from 'path';
 
 const REPO_URL = 'git@github.com:ghostery/ghostery-dnr-lists.git';
+const DNR_LIST_DIR = resolve('src/rule_resources');
 
 shelljs.rm('-rf', 'tmp');
-shelljs.rm('-rf', 'src/assets/rule_resources/*.json');
+shelljs.rm('-rf', DNR_LIST_DIR);
+shelljs.mkdir('-p', DNR_LIST_DIR);
 
 function writeJSONPlaceholder(path, content) {
-  writeFileSync(
-    resolve('src/assets/rule_resources/', path),
-    JSON.stringify(content),
-  );
+  writeFileSync(resolve(DNR_LIST_DIR, path), JSON.stringify(content));
 }
 
 try {
@@ -22,7 +21,7 @@ try {
 
   shelljs.exec('cd tmp/dnr-lists && npm ci && npm start');
 
-  shelljs.cp('-R', 'tmp/dnr-lists/build/*.json', 'src/assets/rule_resources/');
+  shelljs.cp('-R', 'tmp/dnr-lists/build/*.json', DNR_LIST_DIR);
 } catch (e) {
   console.log('Generating placeholder DNR lists');
 

--- a/src/background/adblocker.js
+++ b/src/background/adblocker.js
@@ -27,18 +27,12 @@ const adblockerEngines = {
   },
 };
 
-// TODO: share with frontend
-function getRulesetType(rulesetId) {
-  return rulesetId.split('_')[0];
-}
-
 export async function updateAdblockerEngineStatuses() {
   const enabledRulesetIds =
     await chrome.declarativeNetRequest.getEnabledRulesets();
-  const enabledRulesetTypes = enabledRulesetIds.map(getRulesetType);
   Object.keys(adblockerEngines).map((engineName) => {
     adblockerEngines[engineName].isEnabled =
-      enabledRulesetTypes.indexOf(engineName) > -1;
+      enabledRulesetIds.indexOf(engineName) > -1;
   });
 }
 

--- a/src/background/storage.js
+++ b/src/background/storage.js
@@ -8,39 +8,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0
  */
+import bugs from '../rule_resources/bugs.json';
+import categories from '../rule_resources/categories.json';
+import trackers from '../rule_resources/trackers.json';
+import tracker_domains from '../rule_resources/tracker_domains.json';
 
-// This global will be asynchronously filled during startup,
-// and provides access to the resources.
-//
-// Note: The resources are shipped with the extension, so
-// loading from the local filesystem should be fast.
 const storage = new Map();
+
+storage.set('bugs', bugs);
+storage.set('categories', categories);
+storage.set('trackers', trackers);
+storage.set('tracker_domains', tracker_domains);
+
 export default storage;
-
-const RESOURCES = {
-  bugs: 'assets/rule_resources/bugs.json',
-  categories: 'assets/rule_resources/categories.json',
-  trackers: 'assets/rule_resources/trackers.json',
-  tracker_domains: 'assets/rule_resources/tracker_domains.json',
-};
-
-async function loadResource(storageKey, filename) {
-  const url = chrome.runtime.getURL(filename);
-  const request = await fetch(url);
-  const json = await request.json();
-  storage.set(storageKey, json);
-
-  // Note: for now, only keep it in memory
-  // await chrome.storage.local.set({ [storageKey]: json });
-}
-
-const pendingLoads = Promise.all(
-  Object.entries(RESOURCES).map(([key, resource]) =>
-    loadResource(key, resource),
-  ),
-);
-
-// errors should not happen, as we are loading from the local filesystem
-pendingLoads
-  .then(() => console.debug('Finished loading:', storage))
-  .catch((e) => console.error('Unexpected error while loading resources', e));

--- a/src/manifest.chromium.json
+++ b/src/manifest.chromium.json
@@ -468,19 +468,19 @@
   "declarative_net_request" : {
     "rule_resources" : [
       {
-        "id": "ads_COMMITHASH",
+        "id": "ads",
         "enabled": true,
-        "path": "assets/rule_resources/dnr-ads-network.json"
+        "path": "rule_resources/dnr-ads-network.json"
       },
       {
-        "id": "tracking_COMMITHASH",
+        "id": "tracking",
         "enabled": true,
-        "path": "assets/rule_resources/dnr-tracking-network.json"
+        "path": "rule_resources/dnr-tracking-network.json"
       },
       {
-        "id": "annoyances_COMMITHASH",
+        "id": "annoyances",
         "enabled": true,
-        "path": "assets/rule_resources/dnr-annoyances-network.json"
+        "path": "rule_resources/dnr-annoyances-network.json"
       }
     ]
   },

--- a/src/manifest.safari.json
+++ b/src/manifest.safari.json
@@ -473,19 +473,19 @@
   "declarative_net_request" : {
     "rule_resources" : [
       {
-        "id": "ads_COMMITHASH",
+        "id": "ads",
         "enabled": true,
-        "path": "assets/rule_resources/dnr-safari-ads-network.json"
+        "path": "rule_resources/dnr-safari-ads-network.json"
       },
       {
-        "id": "tracking_COMMITHASH",
+        "id": "tracking",
         "enabled": true,
-        "path": "assets/rule_resources/dnr-safari-tracking-network.json"
+        "path": "rule_resources/dnr-safari-tracking-network.json"
       },
       {
-        "id": "annoyances_COMMITHASH",
+        "id": "annoyances",
         "enabled": true,
-        "path": "assets/rule_resources/dnr-safari-annoyances-network.json"
+        "path": "rule_resources/dnr-safari-annoyances-network.json"
       }
     ]
   },

--- a/src/pages/panel/store/settings.js
+++ b/src/pages/panel/store/settings.js
@@ -10,10 +10,10 @@
  */
 
 import { store } from 'hybrids';
-import { rulesetIds, toggles, getRulesetType } from '../utils/rulesets.js';
+import { rulesetIds } from '../utils/rulesets.js';
 
 const Settings = {
-  blockingStatus: toggles.reduce(
+  blockingStatus: rulesetIds.reduce(
     (all, toggle) => ({ ...all, [toggle]: false }),
     {},
   ),
@@ -21,11 +21,9 @@ const Settings = {
     get: async () => {
       const enabledRulesetIds =
         await chrome.declarativeNetRequest.getEnabledRulesets();
-      const enabledRulesetTypes = enabledRulesetIds.map(getRulesetType);
-      const settings = {
-        blockingStatus: {},
-      };
-      enabledRulesetTypes.forEach((type) => {
+      const settings = { blockingStatus: {} };
+
+      enabledRulesetIds.forEach((type) => {
         settings.blockingStatus[type] = true;
       });
       return settings;
@@ -34,16 +32,15 @@ const Settings = {
   },
 };
 
-export async function toggleBlocking(type) {
+export async function toggleBlocking(rulesetId) {
   const settings = store.get(Settings);
-  const rulesetId = rulesetIds.find((r) => r.startsWith(type));
-  const currentStatus = settings.blockingStatus[type];
+  const currentStatus = settings.blockingStatus[rulesetId];
 
   store.set(Settings, {
     ...settings,
     blockingStatus: {
       ...settings.blockingStatus,
-      [type]: !currentStatus,
+      [rulesetId]: !currentStatus,
     },
   });
 

--- a/src/pages/panel/utils/rulesets.js
+++ b/src/pages/panel/utils/rulesets.js
@@ -12,9 +12,3 @@
 export const rulesetIds = chrome.runtime
   .getManifest()
   .declarative_net_request.rule_resources.map((r) => r.id);
-
-export function getRulesetType(rulesetId) {
-  return rulesetId.split('_')[0];
-}
-
-export const toggles = rulesetIds.map(getRulesetType);

--- a/src/pages/panel/views/simple.js
+++ b/src/pages/panel/views/simple.js
@@ -18,39 +18,13 @@ import {
   chevronRight,
 } from '/vendor/@whotracksme/ui/src/components/icons.js';
 
-import { toggles } from '../utils/rulesets.js';
+import { rulesetIds } from '../utils/rulesets.js';
+import sites from '../../../rule_resources/sites.json';
 
 import Stats from '../store/stats.js';
 import Settings from '../store/settings.js';
 
 import Detailed from './detailed.js';
-
-function wtmLink(stats) {
-  const placeholder = html`<span></span>`;
-  if (!store.ready(stats)) {
-    return placeholder;
-  }
-  const { domain } = stats;
-  const siteListUrl = chrome.runtime.getURL('assets/rule_resources/sites.json');
-  const url = `https://www.whotracks.me/websites/${domain}.html`;
-  const link = html`
-    <a href="${url}" target="_blank">
-      ${t('statistical_report')} ${externalLink}
-    </a>
-  `;
-
-  const promise = fetch(siteListUrl)
-    .then((res) => res.json())
-    .then((res) => {
-      if (res.indexOf(domain) > -1) {
-        return link;
-      }
-      throw Error('No domain entry found');
-    })
-    .catch(() => placeholder);
-
-  return html.resolve(promise, placeholder);
-}
 
 export default define({
   [router.connect]: { stack: [Detailed] },
@@ -62,7 +36,7 @@ export default define({
 
     <section class="toggles">
       ${store.ready(settings) &&
-      toggles.map(
+      rulesetIds.map(
         (toggle) =>
           html`<gh-panel-toggle-switch
             toggle=${toggle}
@@ -74,7 +48,18 @@ export default define({
     html` <wtm-stats categories=${stats.categories}></wtm-stats> `}
 
     <section class="buttons">
-      <span> ${wtmLink(stats)} </span>
+      <span>
+        ${store.ready(stats) &&
+        sites.indexOf(stats.domain) > -1 &&
+        html`
+          <a
+            href="https://www.whotracks.me/websites/${stats.domain}.html"
+            target="_blank"
+          >
+            ${t('statistical_report')} ${externalLink}
+          </a>
+        `}
+      </span>
       <a href="${router.url(Detailed)}">
         ${t('detailed_view')} ${chevronRight}
       </a>

--- a/xcode/Ghostery.xcodeproj/project.pbxproj
+++ b/xcode/Ghostery.xcodeproj/project.pbxproj
@@ -102,6 +102,8 @@
 		B469CA9727BE924D00408C43 /* _locales in Resources */ = {isa = PBXBuildFile; fileRef = B469CA8827BE924D00408C43 /* _locales */; };
 		B469CA9B27BE949000408C43 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = B469CA9A27BE949000408C43 /* manifest.json */; };
 		B469CA9C27BE949000408C43 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = B469CA9A27BE949000408C43 /* manifest.json */; };
+		B4FFD50227F73B830041049C /* rule_resources in Resources */ = {isa = PBXBuildFile; fileRef = B4FFD50127F73B820041049C /* rule_resources */; };
+		B4FFD50327F73B830041049C /* rule_resources in Resources */ = {isa = PBXBuildFile; fileRef = B4FFD50127F73B820041049C /* rule_resources */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -207,6 +209,7 @@
 		B469CA8727BE924D00408C43 /* pages */ = {isa = PBXFileReference; lastKnownFileType = folder; name = pages; path = ../../dist/pages; sourceTree = "<group>"; };
 		B469CA8827BE924D00408C43 /* _locales */ = {isa = PBXFileReference; lastKnownFileType = folder; name = _locales; path = ../../dist/_locales; sourceTree = "<group>"; };
 		B469CA9A27BE949000408C43 /* manifest.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = manifest.json; path = ../../dist/manifest.json; sourceTree = "<group>"; };
+		B4FFD50127F73B820041049C /* rule_resources */ = {isa = PBXFileReference; lastKnownFileType = folder; name = rule_resources; path = ../../dist/rule_resources; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -435,6 +438,7 @@
 		468E42D92701F84A008B5792 /* common */ = {
 			isa = PBXGroup;
 			children = (
+				B4FFD50127F73B820041049C /* rule_resources */,
 				B469CA9A27BE949000408C43 /* manifest.json */,
 				B469CA8827BE924D00408C43 /* _locales */,
 				B469CA8527BE924D00408C43 /* assets */,
@@ -626,6 +630,7 @@
 				B469CA9027BE924D00408C43 /* assets in Resources */,
 				B469CA9427BE924D00408C43 /* pages in Resources */,
 				B469CA9627BE924D00408C43 /* _locales in Resources */,
+				B4FFD50227F73B830041049C /* rule_resources in Resources */,
 				B469CA8C27BE924D00408C43 /* vendor in Resources */,
 				B469CA9B27BE949000408C43 /* manifest.json in Resources */,
 				B469CA8A27BE924D00408C43 /* node_modules in Resources */,
@@ -641,6 +646,7 @@
 				B469CA9127BE924D00408C43 /* assets in Resources */,
 				B469CA9527BE924D00408C43 /* pages in Resources */,
 				B469CA9727BE924D00408C43 /* _locales in Resources */,
+				B4FFD50327F73B830041049C /* rule_resources in Resources */,
 				B469CA8D27BE924D00408C43 /* vendor in Resources */,
 				B469CA9C27BE949000408C43 /* manifest.json in Resources */,
 				B469CA8B27BE924D00408C43 /* node_modules in Resources */,


### PR DESCRIPTION
* `rule_resources` moved out from copying the whole path - DNR lists are now getting from the manifest, only they are copied. The rest is directly imported by scripts, so the build step compiles the JSON into the corresponding JavaScript file in the dist.
* The build script updated to use `declarative_net_request` field
* `download-dnr-lists` script updated to copy files into new location (`src/rule_resources`)
* Clears out the `_COMMITHASH` suffix - fixes #27