### PR TITLE
[POC] Block navigation to a list of domains, eg. malware

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -30,6 +30,7 @@ import {
 } from './adblocker.js';
 
 import './stats.js';
+import './malware.js';
 
 function getTrackerFromUrl(url, origin) {
   try {

--- a/src/background/malware.js
+++ b/src/background/malware.js
@@ -1,0 +1,35 @@
+/**
+ * Ghostery Browser Extension
+ * https://www.ghostery.com/
+ *
+ * Copyright 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0
+ */
+
+let MALWARE_DB = ['apple.com'];
+
+function allowDomain(url) {
+  MALWARE_DB = MALWARE_DB.filter((domain) => !url.includes(domain));
+}
+
+chrome.webNavigation.onCommitted.addListener((event) => {
+  if (event.parentFrameId === -1) {
+    const origin = new URL(event.url).origin;
+    if (MALWARE_DB.some((domain) => origin.includes(domain))) {
+      chrome.tabs.update(event.tabId, {
+        url: chrome.runtime.getURL(
+          `pages/malware/index.html?url=${encodeURIComponent(event.url)}`,
+        ),
+      });
+    }
+  }
+});
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.action === 'malware-allow-domain' && msg.url) {
+    allowDomain(msg.url);
+  }
+});

--- a/src/manifest.chromium.json
+++ b/src/manifest.chromium.json
@@ -488,7 +488,8 @@
   "web_accessible_resources": [
     {
       "resources": [
-        "content_scripts/whotracksme/ghostery-whotracksme.js"
+        "content_scripts/whotracksme/ghostery-whotracksme.js",
+        "pages/malware/index.html"
       ],
       "all_frames": true,
       "matches": [

--- a/src/manifest.safari.json
+++ b/src/manifest.safari.json
@@ -493,6 +493,7 @@
   "web_accessible_resources": [
     "content_scripts/whotracksme/ghostery-whotracksme.js",
     "content_scripts/prevent-indexeddb-tracking/ghostery-prevent-indexeddb-tracking.js",
-    "pages/trackers-preview/index.html"
+    "pages/trackers-preview/index.html",
+    "pages/malware/index.html"
   ]
 }

--- a/src/pages/malware/index.html
+++ b/src/pages/malware/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ghostery Malware Blocker</title>
+    <script src="./index.js" type="module" async></script>
+  </head>
+  <body>
+    <p>The target page was blocked as it might be dangerous</p>
+    <p id="url"></p>
+    <p>
+      <a href="#" id="anchor">Click here</a> if you sure that you want to
+      proceed.
+    </p>
+  </body>
+</html>

--- a/src/pages/malware/index.js
+++ b/src/pages/malware/index.js
@@ -1,0 +1,15 @@
+const searchParams = new URLSearchParams(window.location.search);
+const url = searchParams.get('url');
+
+const anchor = document.getElementById('anchor');
+const text = document.getElementById('url');
+
+anchor.href = url;
+text.textContent = url;
+
+anchor.addEventListener('click', (event) => {
+  event.preventDefault();
+
+  chrome.runtime.sendMessage({ action: 'malware-allow-domain', url });
+  window.location.replace(anchor.href);
+});


### PR DESCRIPTION
After the investigation, it is not possible to use static DNR lists for blocking navigation, as it does not allow to force visits by the user. However, the feature can be implemented without the `WebRequest` API. Here you have a proof of concept, which show how it could work. 

It is not finished logic, and there are some edge cases on Safari, where the webNavigation `onCommitted` event does not fire, etc.. the PR is more or less for the overview of how we can proceed with the feature.