### PR TITLE
Set default values for obsolete options keys

### DIFF
--- a/src/store/options.js
+++ b/src/store/options.js
@@ -29,6 +29,15 @@ const Options = {
   [store.connect]: {
     async get() {
       const { options = {} } = await chrome.storage.local.get(['options']);
+
+      // Set default value for keys, which type does no match the current one
+      Object.entries(options).forEach(([key, value]) => {
+        if (typeof value !== typeof Options[key]) {
+          delete options[key];
+          console.warn(`Saved options "${key}" key has wrong type, deleted`);
+        }
+      });
+
       return options;
     },
     async set(_, options) {


### PR DESCRIPTION
We have pushed to the TestFlight version, which had `options.onboarding` set as a boolean. Recently, after the logic update, I changed it to a nested object. As the code wasn't released, and locally I clear the storage for testing purposes, I did not catch an edge case, where the local storage has this option already saved as a boolean. As the result, with the new code, fetching options breaks, as the store expects that this key is an object (or it is not defined).

The storage on iOS is kept, even though you would clear the cache and history of the Safari, remove the Ghostery app, restart the device, etc...

The change ensures that the options structure will match the required types. If we change a type of the key, it means that we expect that a user with a different type, should have a default value (it is a new value, so it could not be overwritten yet).